### PR TITLE
Support R version 4

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 versions=""
-for major_version in 2 3; do
+for major_version in {2..4}; do
     versions="${versions} $(curl --silent https://mirrors.nics.utk.edu/cran/src/base/R-${major_version}/ | tr '<>' ',,' | awk -F, '/tar.gz/{ print $13 }' | sed -e 's/.tar.gz//g' -e 's/R-//')"
 done
 


### PR DESCRIPTION
R version 4.0.0 (Arbor Day) was released on 2020-04-24. In order to support it, I simply changed the `list-all` script to include major versions 2-4. I used this script to install R version 4.0.0 locally, and it appears to work as expected.