### PR TITLE
List all versions #8 | Fix

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
-versions=""
-for major_version in 2 3; do
-    versions="${versions} $(curl --silent https://mirrors.nics.utk.edu/cran/src/base/R-${major_version}/ | tr '<>' ',,' | awk -F, '/tar.gz/{ print $13 }' | sed -e 's/.tar.gz//g' -e 's/R-//')"
-done
+major=2
 
-echo $versions
+# Act like a do-while loop and iterate though major versions starting a 2 until no minor releases can be found.
+#   And by no minor release found, no lists found on the webpage with no text like '.tar.gz' on it.
+while : ; do
+    major_list="$(curl --silent https://mirrors.nics.utk.edu/cran/src/base/R-${major}/ | tr '<>' ',,' | awk -F, '/tar.gz/{ print $13 }' | sed -e 's/.tar.gz//g' -e 's/R-//')"
+    [[ $major_list == '' ]] && break
+    echo "$major_list"
+    major=$(( $major + 1 ))
+done


### PR DESCRIPTION
Fix to list-all

This pull-request iterates and lists all the major versions of R starting at 2.
It will keep checking major releases until no minor releases are found.

Hopefully, this will future proof it against future major releases assuming the HTML page doesn't change so drastically that `awk` can't find the release links.