### PR TITLE
Fix the list-all | Issue #14

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 
+# Start the list at major version 2
 major=2
+
+# collect all the versions in this
+versions=()
 
 # Act like a do-while loop and iterate though major versions starting a 2 until no minor releases can be found.
 #   And by no minor release found, no lists found on the webpage with no text like '.tar.gz' on it.
 while : ; do
     major_list="$(curl --silent https://mirrors.nics.utk.edu/cran/src/base/R-${major}/ | tr '<>' ',,' | awk -F, '/tar.gz/{ print $13 }' | sed -e 's/.tar.gz//g' -e 's/R-//')"
     [[ $major_list == '' ]] && break
-    echo "$major_list"
+    versions+=($major_list)
     major=$(( $major + 1 ))
 done
+
+echo ${versions[@]}


### PR DESCRIPTION
ASDF VM expects the versions to be listed as space-delimited, not EOL-delimited.
Fixed it from EOL delimited to space.

---

Sorry about that, I tested the shell script alone and not as an ASDF VM.

According to the [plug-in guide](https://asdf-vm.com/#/plugins-create), it expects a space-delimited list for the `list-all` script and I used EOL-delimited so it only listed the first version on the list.

I updated it to space-delimited.

Next time I'll test it as a plugin and not as a separate script.

Once again, sorry about that.